### PR TITLE
fix: 🐛 fix remove extensionField

### DIFF
--- a/src/root.js
+++ b/src/root.js
@@ -329,7 +329,8 @@ Root.prototype._handleRemove = function _handleRemove(object) {
 
         if (/* an extension field */ object.extend !== undefined) {
             if (/* already handled */ object.extensionField) { // remove its sister field
-                object.extensionField.parent.remove(object.extensionField);
+                if (object.extensionField.parent)
+                    object.extensionField.parent.remove(object.extensionField);
                 object.extensionField = null;
             } else { // cancel the extension
                 var index = this.deferred.indexOf(object);


### PR DESCRIPTION
fix `pbjs --sparse` error:
`TypeError: Cannot read properties of null (reading 'remove')`

The above error appeared after merging #4