### PR TITLE
fix: 🐛 fix encode int64

### DIFF
--- a/src/util/longbits.js
+++ b/src/util/longbits.js
@@ -20,13 +20,13 @@ function LongBits(lo, hi) {
      * Low bits.
      * @type {number}
      */
-    this.lo = lo | 0;
+    this.lo = lo;
 
     /**
      * High bits.
      * @type {number}
      */
-    this.hi = hi | 0;
+    this.hi = hi;
 }
 
 /**
@@ -56,8 +56,8 @@ LongBits.fromBigInt = function fromNumber(value) {
     if (negative) {
         value = -value;
     }
-    var hi = Number(value >> 32n) | 0;
-    var lo = Number(value - ( BigInt(hi) << 32n ) ) | 0;
+    var hi = Number(value >> 32n);
+    var lo = Number(value - ( BigInt(hi) << 32n ) );
 
     if (negative) {
         hi = ~hi >>> 0;


### PR DESCRIPTION
```
uint64 4294967296n -> `188080808010`
uint64 4294967295n -> `18ffffffff0f`
uint64 2254038901n -> `18f5cee7b208`
uint64 18446744073709551615n -> `18ffffffffffffffffff01`
sint64 -233n -> `50d103`
```